### PR TITLE
build: introduce JVM toolchain and foojay plugin

### DIFF
--- a/buildSrc/src/main/kotlin/net.orekyuu.java-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.orekyuu.java-base.gradle.kts
@@ -9,6 +9,9 @@ repositories {
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 tasks.withType<Test> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,8 @@
  * For more detailed information on multi-project builds, please refer to https://docs.gradle.org/8.5/userguide/building_swift_projects.html in the Gradle documentation.
  */
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
+}
 rootProject.name = "java-gradle-project-best-practice"
 include(":core", ":extensions:base", ":extensions:console")


### PR DESCRIPTION
現在の設定はJavaの21以降が`JAVA_HOME`に入っていないとビルドできないようになっています。

[JVM toolchain](https://docs.gradle.org/current/userguide/toolchains.html)を利用すると、Gradleが実行されるJavaとは異なるJVMをビルドスクリプトで指定して利用できます。つまりGradleがJava 8で実行されていても、コンパイルにはJava 21を使うことができます。これはチームで開発するときに各プログラマがどんなJavaを`JAVA_HOME`に入れているかを気にする必要がなくなるという利点があり重宝します。

また[auto-provisioningを使う](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning)と必要なJavaが見つからなかった場合にインストールを行えます。ここではfoojayプラグインを入れて、Java 21が見つからなかった場合にインストールしてそれを利用するようにしました。