### PR TITLE
Dependenciesの利用を細分化

### DIFF
--- a/buildSrc/src/main/kotlin/net.orekyuu.java-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.orekyuu.java-base.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    java
+    `java-library`
 }
 
 repositories {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 dependencies {
     implementation(project(":extensions:base"))
-    implementation(project(":extensions:console"))
+    runtimeOnly(project(":extensions:console"))
 }

--- a/extensions/console/build.gradle.kts
+++ b/extensions/console/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":extensions:base"))
+    api(project(":extensions:base"))
 }


### PR DESCRIPTION
Gradle 5から [`implementation` と `api` の分離](https://docs.gradle.org/8.5/userguide/java_library_plugin.html#sec:java_library_separation)が推奨されました。これを使うことで、不要な推移的依存を削減することができます。

簡単に言うとインタフェースとして露出している依存に `api` を使おうということです。このプロジェクトでは `:extensions:console` は `:extensions:base` に含まれるインタフェースを実装しているので `api` を使う必要があります。なお `api` は一般に少ないほうがいいです（refs http://jlbp.dev/JLBP-2）。

なお、この依存の分離を使うためには `java` プラグインを `java-library` プラグインにする必要があります。大きな問題はないですが、厳密には `:core` はライブラリではなく実行可能JARをつくるプロジェクトなので、 `application` プラグインを適用するほうが適切かもしれないです。ただ現時点では気にしなくて良いかなと思いました。